### PR TITLE
Fix: fixing execution commands

### DIFF
--- a/lua/smart-runner/init.lua
+++ b/lua/smart-runner/init.lua
@@ -9,17 +9,17 @@ M.defaults = {
 
   -- default commands per archive type
   commands = {
-    py = "python3",
+    py = "python3 %f",
     java = "javac %f && java %c",
-    js = "node",
-    ts = "ts-node",
+    js = "node %f",
+    ts = "ts-node %f",
     c = "gcc %f -o %e && ./%e",
     cpp = "g++ %f -o %e && ./%e",
-    sh = "bash",
-    go = "go run",
+    sh = "bash %f",
+    go = "go run %f",
     rs = "rustc %f && ./%e",
-    php = "php",
-    lua = "lua",
+    php = "php %f",
+    lua = "lua %f",
   },
 }
 


### PR DESCRIPTION
[This was generated by Copilot]

This pull request updates the default commands in the `lua/smart-runner/init.lua` file to include the `%f` placeholder, ensuring that the file being executed is explicitly specified in each command. This change improves clarity and consistency in how commands are defined for different file types.

### Updates to default commands:

* Updated the `commands` table to include `%f` (file placeholder) for the following file types: Python (`py`), JavaScript (`js`), TypeScript (`ts`), Shell (`sh`), Go (`go`), PHP (`php`), and Lua (`lua`). This ensures that the file being executed is explicitly passed as an argument.