### PR TITLE
Feat/adding tests and changing readme

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,12 +43,11 @@ jobs:
       # 3. Install Neovim
       - name: Install Neovim
         run: |
-          curl -LO https://github.com/neovim/neovim/releases/latest/download/nvim.appimage
+          curl -LO -L https://github.com/neovim/neovim/releases/latest/download/nvim.appimage
           chmod u+x nvim.appimage
           ./nvim.appimage --appimage-extract
           sudo mv squashfs-root /usr
           sudo ln -s /usr/bin/nvim /usr/local/bin/nvim
-
       # 4. Run the tests!
       - name: Run tests
         run: |
@@ -89,6 +88,6 @@ jobs:
           run_test "examples/HelloWorld.rs" "Hello from Rust!"
           
           # Tests for the sample projects
-          run_test "test-projects/maven-hello-world/src/main/java/com/example/App.java" "Hello from Maven!"
+          run_test "examples/projects/maven-hello-world/src/main/java/com/example/App.java" "Hello from Maven!"
 
           echo "All tests passed successfully!"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,94 @@
+name: CI
+
+# Triggers the workflow on pushes and pull requests to the main branch
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      # 1. Download the code from your repository
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # 2. Install all language dependencies
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Set up Java and Maven
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: 'maven'
+      - name: Install other language runtimes
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc g++ lua5.4 rustc php-cli
+
+      # 3. Install Neovim
+      - name: Install Neovim
+        run: |
+          curl -LO https://github.com/neovim/neovim/releases/latest/download/nvim.appimage
+          chmod u+x nvim.appimage
+          ./nvim.appimage --appimage-extract
+          sudo mv squashfs-root /usr
+          sudo ln -s /usr/bin/nvim /usr/local/bin/nvim
+
+      # 4. Run the tests!
+      - name: Run tests
+        run: |
+          # Function to run a test and check the output
+          run_test() {
+            local file_path=$1
+            local expected_output=$2
+            echo "--- Testing $file_path ---"
+            
+            # Run Neovim with the plugin and capture terminal output
+            # NOTE: Neovim displays notifications in the error output (stderr)
+            local output=$(nvim --headless -u NONE \
+              -c "set rtp+=." \
+              -c "lua require('smart-runner').setup()" \
+              -c "e $file_path" \
+              -c "lua require('smart-runner').run()" 2>&1)
+            
+            echo "$output"
+            
+            # Check if the expected output is present
+            if ! echo "$output" | grep -q "$expected_output"; then
+              echo "Error: Test failed for $file_path. Expected output not found."
+              exit 1
+            fi
+            echo "Success: Test passed for $file_path."
+            echo "--------------------------"
+          }
+
+          # Tests for the example files
+          run_test "examples/HelloWorld.py" "Hello from Python!"
+          run_test "examples/HelloWorld.js" "Hello from JavaScript!"
+          run_test "examples/HelloWorld.go" "Hello from Go!"
+          run_test "examples/HelloWorld.lua" "Hello from Lua!"
+          run_test "examples/HelloWorld.php" "Hello from PHP!"
+          run_test "examples/HelloWorld.sh" "Hello from Shell!"
+          run_test "examples/HelloWorld.c" "Hello from C!"
+          run_test "examples/HelloWorld.cpp" "Hello from C++!"
+          run_test "examples/HelloWorld.rs" "Hello from Rust!"
+          
+          # Tests for the sample projects
+          run_test "test-projects/maven-hello-world/src/main/java/com/example/App.java" "Hello from Maven!"
+
+          echo "All tests passed successfully!"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,91 @@
 # smart-runner.nvim
-A Neovim plugin for executing code.
+
+A simple and intelligent code runner plugin for Neovim, designed to execute the current file with a single key press.
+
+It automatically detects the file type and chooses the correct execution command, with special support for Maven projects and automatic cleanup of compiled artifacts.
+
+## ✨ Features
+
+  * **One-Key Execution:** Run your code with a single, configurable keymap (defaults to `<F5>`).
+  * **Automatic Language Detection:** Out-of-the-box support for Python, Java, C, C++, JavaScript, Go, Rust, and more.
+  * **Smart Maven Support:** Automatically detects if a Java file is part of a Maven project and runs `mvn compile exec:java` instead of the standard `javac`.
+  * **Automatic Cleanup:** Removes compiled artifacts (`.class` files, binaries, etc.) after execution to keep your working directory clean.
+  * **Highly Configurable:** Easily change the keymap or add support for new languages.
+
+## 💾 Installation
+
+It is recommended to use a modern plugin manager like [lazy.nvim](https://github.com/folke/lazy.nvim).
+
+### For Neovim Users (with `lazy.nvim`)
+
+Add the following to your Neovim plugin configuration:
+
+```lua
+{
+  "mikaelgois/smart-runner.nvim",
+  -- 'opts' is optional and is used to configure the plugin.
+  opts = {},
+}
+```
+
+### For LunarVim Users
+
+Add the plugin to your `lvim.plugins` list in your `config.lua` file:
+
+```lua
+-- In your ~/.config/lvim/config.lua
+lvim.plugins = {
+  -- ... other plugins
+  
+  {
+    "mikaelgois/smart-runner.nvim",
+    opts = {} 
+  }
+}
+```
+
+## ⚙️ Configuration (Optional)
+
+You can customize the plugin by passing an `opts` table when you `setup` or declare the plugin.
+
+**Full Configuration Example:**
+
+```lua
+{
+  "mikaelgois/smart-runner.nvim",
+  opts = {
+    -- Change the default keymap from <F5> to <leader>r
+    keymap = "<leader>r",
+    
+    -- Modify the commands table
+    commands = {
+      -- Override an existing command (e.g., use 'python' instead of 'python3')
+      py = "python %f",
+      
+      -- Add a new command for an unsupported language (e.g., Zig)
+      zig = "zig run %f",
+      
+      -- Remove support for a language by setting it to nil
+      php = nil, 
+    }
+  }
+}
+```
+
+### Command Placeholders
+
+When defining custom commands, you can use the following placeholders:
+
+  * `%f`: Will be replaced by the **filename** with its extension (e.g., `script.py`).
+  * `%c`: Will be replaced by the **class name** or filename without extension (e.g., `HelloWorld`).
+  * `%e`: Will be replaced by the **executable name**, usually the filename without extension (e.g., `HelloWorld`).
+
+## 🚀 Usage
+
+1.  Open any file from a supported language.
+2.  Press the configured key (defaults to `<F5>`).
+3.  A new terminal window will split open and execute your code.
+
+## 📜 License
+
+This project is licensed under the **GPL-3.0 License**. See the `LICENSE` file for more details.

--- a/examples/HelloWorld.c
+++ b/examples/HelloWorld.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main() {
+    printf("Hello from C!\n");
+    return 0;
+}

--- a/examples/HelloWorld.cpp
+++ b/examples/HelloWorld.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main() {
+    std::cout << "Hello from C++!" << std::endl;
+    return 0;
+}

--- a/examples/HelloWorld.go
+++ b/examples/HelloWorld.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+    fmt.Println("Hello from Go!")
+}

--- a/examples/HelloWorld.java
+++ b/examples/HelloWorld.java
@@ -1,0 +1,5 @@
+public class HelloWorld {
+    public static void main(String[] args) {
+        System.out.println("Hello from Java!");
+    }
+}

--- a/examples/HelloWorld.js
+++ b/examples/HelloWorld.js
@@ -1,0 +1,1 @@
+console.log("Hello from JavaScript!");

--- a/examples/HelloWorld.lua
+++ b/examples/HelloWorld.lua
@@ -1,0 +1,1 @@
+print("Hello from Lua!")

--- a/examples/HelloWorld.php
+++ b/examples/HelloWorld.php
@@ -1,0 +1,3 @@
+<?php
+echo "Hello from PHP!\n";
+?>

--- a/examples/HelloWorld.py
+++ b/examples/HelloWorld.py
@@ -1,0 +1,1 @@
+print("Hello from Python!")

--- a/examples/HelloWorld.rs
+++ b/examples/HelloWorld.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello from Rust!");
+}

--- a/examples/HelloWorld.sh
+++ b/examples/HelloWorld.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "Hello from Shell!"

--- a/examples/projects/maven-hello-world/pom.xml
+++ b/examples/projects/maven-hello-world/pom.xml
@@ -1,0 +1,27 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>maven-hello-world</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.release>8</maven.compiler.release>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <mainClass>com.example.App</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/projects/maven-hello-world/src/main/java/com/example/App.java
+++ b/examples/projects/maven-hello-world/src/main/java/com/example/App.java
@@ -1,0 +1,7 @@
+package com.example;
+
+public class App {
+    public static void main(String[] args) {
+        System.out.println("Hello from Maven!");
+    }
+}

--- a/lua/smart-runner/init.lua
+++ b/lua/smart-runner/init.lua
@@ -9,57 +9,63 @@ M.defaults = {
 
   -- default commands per archive type
   commands = {
+    -- scripts
     py = "python3 %f",
-    java = "javac %f && java %c",
     js = "node %f",
     ts = "ts-node %f",
-    c = "gcc %f -o %e && ./%e",
-    cpp = "g++ %f -o %e && ./%e",
     sh = "bash %f",
-    go = "go run %f",
-    rs = "rustc %f && ./%e",
     php = "php %f",
     lua = "lua %f",
+
+    -- compiled
+    java = "javac %f && java %c; rm %c.class",
+    c = "gcc %f -o %e && ./%e; rm %e",
+    cpp = "g++ %f -o %e && ./%e; rm %e",
+    go = "go run %f",
+    rs = "rustc %f && ./%e; rm %e",
   },
 }
+
+function M.run()
+  vim.cmd("silent! w") -- saves file before run
+  local ext = vim.fn.expand("%:e") -- identify file extension
+  local pom_path = vim.fn.findfile('pom.xml', '.;') -- find a pom file for maven projects
+
+  -- for maven projects
+  if pom_path ~= '' and pom_path ~= nil and ext == 'java' then
+    vim.notify("Maven project detected! Running the application...", vim.log.levels.INFO)
+    vim.cmd("split")
+    vim.cmd("terminal mvn compile exec:java")
+    return
+  end
+
+  -- for other files
+  local file_dir = vim.fn.expand("%:h")
+  local file_name = vim.fn.expand("%:t")
+  local file_no_ext = vim.fn.expand("%:t:r")
+
+  local config = vim.tbl_deep_extend("force", M.defaults, {})
+  local template = config.commands[ext]
+
+  if template then
+    local command = template:gsub("%%f", file_name):gsub("%%c", file_no_ext):gsub("%%e", file_no_ext)
+    local final_command = "cd '" .. file_dir .. "' && " .. command
+
+    vim.notify("Running command for: " .. ext, vim.log.levels.INFO)
+    vim.cmd("split")
+    vim.cmd("terminal " .. final_command)
+  else
+    vim.notify("No action defined for extension: " .. ext, vim.log.levels.ERROR)
+  end
+end
 
 function M.setup(opts)
   local config = vim.tbl_deep_extend("force", M.defaults, opts or {})
 
-  local function run_file()
-    vim.cmd("silent! w") -- saves file before run
-    local ext = vim.fn.expand("%:e") -- identify file extension
-    local pom_path = vim.fn.findfile('pom.xml', '.;') -- find a pom file for maven projects
-
-    -- for maven projects
-    if pom_path ~= '' and pom_path ~= nil and ext == 'java' then
-      vim.notify("Maven project detected! Running the application...", vim.log.levels.INFO)
-      vim.cmd("split")
-      vim.cmd("terminal mvn compile exec:java")
-      return 
-    end
-
-    -- for other files
-    local file_dir = vim.fn.expand("%:h")
-    local file_name = vim.fn.expand("%:t")
-    local file_no_ext = vim.fn.expand("%:t:r")
-
-    local template = config.commands[ext]
-
-    if template then
-      local command = template:gsub("%%f", file_name):gsub("%%c", file_no_ext):gsub("%%e", file_no_ext)
-      local final_command = "cd '" .. file_dir .. "' && " .. command
-
-      vim.notify("Running command for: " .. ext, vim.log.levels.INFO)
-      vim.cmd("split")
-      vim.cmd("terminal " .. final_command)
-    else
-      vim.notify("No action defined for extension: " .. ext, vim.log.levels.ERROR)
-    end
-  end
-
-  vim.keymap.set("n", config.keymap, run_file, { desc = "Smart Runner: Run file" })
-  vim.notify("Smart Runner loaded! Shortcut: " .. config.keymap, vim.log.levels.INFO)
+  vim.keymap.set("n", config.keymap, M.run, { desc = "Smart Runner: Run file" })
+  vim.schedule(function()
+    vim.notify("Smart Runner loaded! Shortcut: " .. config.keymap, vim.log.levels.INFO)
+  end)
 end
 
 return M


### PR DESCRIPTION
[This was generated by Copilot]

This pull request introduces a comprehensive set of changes to the `smart-runner.nvim` plugin, focusing on enhancing its functionality, improving usability, and adding robust testing. The changes include a new CI workflow, updates to the plugin's default behavior, the addition of example files, and expanded documentation.

### CI and Testing Enhancements
* Added a new CI workflow in `.github/workflows/ci.yaml` to automate testing across multiple languages and ensure compatibility with Neovim. The workflow includes language setup, Neovim installation, and a series of tests for example files and Maven projects.

### Plugin Improvements
* Updated the default `commands` configuration in `lua/smart-runner/init.lua` to include automatic cleanup of compiled artifacts (e.g., `.class` files for Java, binaries for C/C++).
* Refactored the `setup` function to separate the logic for running files (`M.run`) and setting up keymaps, improving modularity and maintainability. [[1]](diffhunk://#diff-6b5503ff3383c3f367982511c337aa7f487f010655acb48c6a947ce629861dc0R47) [[2]](diffhunk://#diff-6b5503ff3383c3f367982511c337aa7f487f010655acb48c6a947ce629861dc0L61-R68)

### Documentation Updates
* Expanded the `README.md` with detailed installation instructions, configuration options, and feature descriptions, making it easier for users to understand and customize the plugin.

### Example Files
* Added example "Hello World" files for various programming languages (`examples/HelloWorld.*`) and a Maven project (`examples/projects/maven-hello-world`) to demonstrate plugin functionality and serve as test cases. [[1]](diffhunk://#diff-2b65743a47bedce941bcd0eb9610b2e8595bc1c3de1d20c4200ab7b450125d62R1-R6) [[2]](diffhunk://#diff-6279c7ef364e98759610f486c1198dc6e8d10e6e24798dc13384eaebb3add405R1-R6) [[3]](diffhunk://#diff-6250dcfb0416bdfc8020725be3ad13729b6a6b234c42bf2c270806d524f9405aR1-R7) [[4]](diffhunk://#diff-896e9f6ed3753bc52c5bcdc11cc8cbc1f43ca1efa0bc4e295b3b98895f9895cbR1-R5) [[5]](diffhunk://#diff-2aa300cd3450b4ef4a4f2c942b147bb53dbedd56da3ccc8b1520c0cd9924f5d7R1) [[6]](diffhunk://#diff-525495d791cc5c67659c04e61e83f870812ef87f118f9d7b0cc7cba82a166256R1) [[7]](diffhunk://#diff-0e3dc328f9233c8fd89cab50bfeb061dc123248006f8472afa3a45af44e2622eR1-R3) [[8]](diffhunk://#diff-a0e3f285921c16f6022ba21a0e60d6dcadb2d4986ef68921b4ad6471688346c4R1) [[9]](diffhunk://#diff-6168d5fd1a1d54cd17ba572600d37522282c0e1be951e53e8004e325755f9a29R1-R3) [[10]](diffhunk://#diff-14626f131dad3f1b867d85fbdf8be473872fa235404dab2c7d3d0d961ff1de64R1-R2) [[11]](diffhunk://#diff-81c7e894244f1c1e2542a976460bc88274d00fa1f5895e4a6f7c8809826c034bR1-R27) [[12]](diffhunk://#diff-8abcd0ae41bbfbc2271b3cd954160413be04798842c671738942cc22cdd0616bR1-R7)